### PR TITLE
fixed the exam bug

### DIFF
--- a/backend/src/game/game.logic.ts
+++ b/backend/src/game/game.logic.ts
@@ -132,11 +132,6 @@ export class GameRoom {
     if (player.id !== userId) throw new Error('Not your turn');
     if (this.state.diceValue !== null) throw new Error('You already rolled');
 
-    // Check if player is stuck on piscineExam
-    if (player.stuckOnPiscineExam) {
-      throw new Error('You must complete the Piscine Exam before rolling');
-    }
-
     // Check if player needs to skip turns
     if (player.turnsToSkip > 0) {
       player.turnsToSkip--;
@@ -331,8 +326,6 @@ export class GameRoom {
       }
 
       case 'piscineExam': {
-        // Player is stuck on this tile until they answer correctly
-        player.stuckOnPiscineExam = true;
         // Pick a random question
         const qIndex = Math.floor(Math.random() * CODING_QUESTIONS.length);
         const question = CODING_QUESTIONS[qIndex];
@@ -370,14 +363,13 @@ export class GameRoom {
     const player = this.state.players.find((p) => p.id === userId);
     if (!player) throw new Error('Player not found');
 
-    const wasPiscineExam = player.stuckOnPiscineExam;
+    // Check if this was a piscineExam challenge (tile 9)
+    const isPiscineExam = player.position === 9;
 
     if (answerIndex === question.correctIndex) {
       player.coins += question.rewardCoins;
       
-      // Release from piscineExam if they were stuck
-      if (wasPiscineExam) {
-        player.stuckOnPiscineExam = false;
+      if (isPiscineExam) {
         this.state.lastMoveDescription = `✅ Correct! ${player.username} passed the Piscine Exam and earned ${question.rewardCoins} coins!`;
       } else {
         this.state.lastMoveDescription = `✅ Correct! ${player.username} earned ${question.rewardCoins} coins!`;
@@ -394,14 +386,10 @@ export class GameRoom {
         }
       });
     } else {
-      // For piscineExam, player remains stuck if they get it wrong
-      if (wasPiscineExam) {
-        this.state.lastMoveDescription = `❌ Wrong! ${player.username} returns 1 tile. The correct answer was: ${question.options[question.correctIndex]}`;
-        // Don't clear challenge, keep player stuck - they must try again
-        this.state.activeChallenge = null;
+      // For piscineExam, move player back 1 tile
+      if (isPiscineExam) {
         player.position = Math.max(0, player.position - 1);
-        // Don't move to next turn, current player stays
-        return this.state;
+        this.state.lastMoveDescription = `❌ Wrong! ${player.username} moves back 1 tile. The correct answer was: ${question.options[question.correctIndex]}`;
       } else {
         this.state.lastMoveDescription = `❌ Wrong! The correct answer was: ${question.options[question.correctIndex]}`;
       }


### PR DESCRIPTION
This pull request refactors the way the "Piscine Exam" tile is handled in the game logic, simplifying the state management and improving the flow for players who land on this tile. The main change is the removal of the `stuckOnPiscineExam` flag, with logic now directly tied to the player's position. This reduces complexity and potential bugs related to state tracking.

**Refactor of Piscine Exam logic:**

* Removed the `stuckOnPiscineExam` flag from the player state, eliminating the need to track if a player is "stuck" on the Piscine Exam tile. Now, the game checks if the player's position is on the Piscine Exam tile (tile 9) to determine their state. [[1]](diffhunk://#diff-26b79a5c20304ccf8ba435a55100e2df72f8ff541d7828e99976db676182b35eL135-L139) [[2]](diffhunk://#diff-26b79a5c20304ccf8ba435a55100e2df72f8ff541d7828e99976db676182b35eL334-L335)
* Updated the answer handling logic so that if a player answers incorrectly on the Piscine Exam tile, they are moved back one tile instead of remaining "stuck." The player's turn then proceeds as normal, rather than forcing them to repeat the challenge until correct. [[1]](diffhunk://#diff-26b79a5c20304ccf8ba435a55100e2df72f8ff541d7828e99976db676182b35eL373-R372) [[2]](diffhunk://#diff-26b79a5c20304ccf8ba435a55100e2df72f8ff541d7828e99976db676182b35eL397-R392)
* Adjusted feedback messages to reflect the new behavior: correct answers on the Piscine Exam tile result in a pass, while incorrect answers move the player back and display the correct answer. [[1]](diffhunk://#diff-26b79a5c20304ccf8ba435a55100e2df72f8ff541d7828e99976db676182b35eL373-R372) [[2]](diffhunk://#diff-26b79a5c20304ccf8ba435a55100e2df72f8ff541d7828e99976db676182b35eL397-R392)