### PR TITLE
added go to home at end of the game

### DIFF
--- a/frontend/src/features/game/pages/GamePage.tsx
+++ b/frontend/src/features/game/pages/GamePage.tsx
@@ -379,9 +379,15 @@ export const GamePage = () => {
           </div>
           <button
             onClick={createNewGame}
-            className="bg-white text-indigo-600 font-black py-4 px-12 rounded-full shadow-2xl hover:scale-110 active:scale-95 transition-all"
+            className="mt-4 bg-white text-indigo-600 font-black py-4 px-12 rounded-full shadow-2xl hover:scale-110 active:scale-95 transition-all"
           >
             PLAY AGAIN
+          </button>
+          <button
+            onClick={() => navigate('/')}
+            className="mt-4 bg-white text-indigo-600 font-black py-4 px-12 rounded-full shadow-2xl hover:scale-110 active:scale-95 transition-all"
+          >
+            GO TO HOME
           </button>
         </div>
       )}


### PR DESCRIPTION
This pull request adds a new navigation option to the game page, allowing users to return to the home screen more easily.

UI improvements:

* Added a "GO TO HOME" button to the end-of-game screen in `GamePage`, which navigates users back to the home page.
* Added a top margin (`mt-4`) to the "PLAY AGAIN" button for improved spacing.