### PR TITLE
changed button at kick to Go Home

### DIFF
--- a/frontend/src/features/game/components/GameControls.tsx
+++ b/frontend/src/features/game/components/GameControls.tsx
@@ -8,7 +8,6 @@ interface GameControlsProps {
   onRoll: () => void;
   onMove: (diceValue: number) => void;
   gameOver: boolean;
-  onReset: () => void;
   disabled?: boolean;
   rollLabel?: string;
   rollAvailableAt?: number | string | null;
@@ -23,7 +22,6 @@ export const GameControls = ({
   onRoll,
   onMove,
   gameOver,
-  onReset,
   disabled,
   rollLabel,
   rollAvailableAt,

--- a/frontend/src/features/game/pages/GamePage.tsx
+++ b/frontend/src/features/game/pages/GamePage.tsx
@@ -288,7 +288,6 @@ export const GamePage = () => {
               onRoll={handleRoll}
               onMove={handleMove}
               gameOver={gameState.gameOver}
-              onReset={createNewGame}
               disabled={isRollDisabled}
               rollAvailableAt={gameState.rollAvailableAt}
             />


### PR DESCRIPTION
This pull request makes a small change to the `GameControls` component. When the game is over, the button now redirects the user to the home page instead of resetting the game.

* Changed the game over button in `GameControls` to redirect to the home page (`'/'`) instead of calling `onReset`.